### PR TITLE
Fix: 500 Internal Server Error on Registration with Long Name

### DIFF
--- a/src/routes/users-routes.ts
+++ b/src/routes/users-routes.ts
@@ -8,9 +8,9 @@ export const usersRoutes = new Elysia({ prefix: "/api/users" })
     return { data };
   }, {
     body: t.Object({
-      name: t.String(),
-      email: t.String({ format: 'email' }),
-      password: t.String(),
+      name: t.String({ maxLength: 255 }),
+      email: t.String({ format: 'email', maxLength: 255 }),
+      password: t.String({ maxLength: 255 }),
     })
   })
   .post("/login", async ({ body }) => {
@@ -25,7 +25,7 @@ export const usersRoutes = new Elysia({ prefix: "/api/users" })
   .use(auth)
   .get("/current", async ({ token }) => {
     if (!token) throw new Error("Unauthorized");
-    
+
     const data = await usersService.getCurrentUser(token);
     return { data };
   })


### PR DESCRIPTION
Fixes #14. Added maxLength validation for name, email, and password in the registration route to match database schema constraints.